### PR TITLE
Allow options for bower install

### DIFF
--- a/djangobower/bower.py
+++ b/djangobower/bower.py
@@ -25,10 +25,10 @@ class BowerAdapter(object):
         if not os.path.exists(self._components_root):
             os.mkdir(self._components_root)
 
-    def install(self, packages):
+    def install(self, packages, *options):
         """Install package from bower"""
         proc = subprocess.Popen(
-            [self._bower_path, 'install'] + list(packages),
+            [self._bower_path, 'install'] + list(options) + list(packages),
             cwd=self._components_root,
         )
         proc.wait()

--- a/djangobower/management/commands/bower_install.py
+++ b/djangobower/management/commands/bower_install.py
@@ -8,4 +8,4 @@ class Command(BaseBowerCommand):
 
     def handle(self, *args, **options):
         super(Command, self).handle(*args, **options)
-        bower_adapter.install(settings.BOWER_INSTALLED_APPS)
+        bower_adapter.install(settings.BOWER_INSTALLED_APPS, *args)


### PR DESCRIPTION
I think it would be nice if we could pass any remaining options straight to the bower executable.

For example, if you have to run as root against the bower's patronising advice:

```
./manage.py bower_install -- --allow-root 
```

If you try to run as root without `--allow-root` you get:

```
# ./manage.py bower_install
bower ESUDO         Cannot be run with sudo

Additional error details:
Since bower is a user command, there is no need to execute it with superuser permissions.
If you're having permission errors when using bower without sudo, please spend a few minutes
learning more about how your system should work and make any necessary repairs.

http://www.joyent.com/blog/installing-node-and-npm
https://gist.github.com/isaacs/579814

You can however run a command with sudo using --allow-root option
```
