### PR TITLE
Add a generic `bower` command

### DIFF
--- a/djangobower/bower.py
+++ b/djangobower/bower.py
@@ -25,13 +25,17 @@ class BowerAdapter(object):
         if not os.path.exists(self._components_root):
             os.mkdir(self._components_root)
 
-    def install(self, packages, *options):
-        """Install package from bower"""
+    def call_bower(self, *args):
+        """Call bower with a list of args"""
         proc = subprocess.Popen(
-            [self._bower_path, 'install'] + list(options) + list(packages),
+            [self._bower_path] + list(args),
             cwd=self._components_root,
         )
         proc.wait()
+
+    def install(self, packages, *options):
+        """Install packages from bower"""
+        self.call_bower(['install'] + list(options) + list(packages))
 
     def _accumulate_dependencies(self, data):
         """Accumulate dependencies"""

--- a/djangobower/management/commands/bower.py
+++ b/djangobower/management/commands/bower.py
@@ -1,0 +1,10 @@
+from ...bower import bower_adapter
+from ..base import BaseBowerCommand
+
+
+class Command(BaseBowerCommand):
+    help = 'Call bower in components root (%s).' % (bower_adapter._components_root)
+
+    def handle(self, *args, **options):
+        super(Command, self).handle(*args, **options)
+        bower_adapter.call_bower(*args)


### PR DESCRIPTION
This allows for calling bower in the components root directory, e.g.:

```
manage.py bower list
manage.py bower list -- -j
```

This will also allow `manage.py bower install foo`, but won't add it to `BOWER_INSTALLED_APPS`, which might be confusing.
