### PR TITLE
Use 'bower_components' as default BOWER_COMPONENTS_ROOT

### DIFF
--- a/djangobower/conf.py
+++ b/djangobower/conf.py
@@ -2,7 +2,7 @@ import os, sys
 
 from django.conf import settings
 
-COMPONENTS_ROOT = getattr(settings, 'BOWER_COMPONENTS_ROOT', os.path.join(settings.BASE_DIR, 'bower_components'))
+COMPONENTS_ROOT = getattr(settings, 'BOWER_COMPONENTS_ROOT', settings.BASE_DIR)
 
 BOWER_PATH_DEFAULT = 'bower'
 if sys.platform == 'win32':


### PR DESCRIPTION
Just adding the bower command default download path.
