### PR TITLE
Fix deadlock in freeze

### DIFF
--- a/djangobower/bower.py
+++ b/djangobower/bower.py
@@ -66,11 +66,8 @@ class BowerAdapter(object):
             cwd=conf.COMPONENTS_ROOT,
             stdout=subprocess.PIPE,
         )
-        proc.wait()
-
-        output = proc.stdout.read().decode(
-            sys.getfilesystemencoding(),
-        )
+        outs, errs = proc.communicate()
+        output = outs.decode(sys.getfilesystemencoding())
 
         try:
             packages = self._parse_package_names(output)


### PR DESCRIPTION
django-bower uses ``Popen.wait()`` but it should use ``Popen.communicate()``.  See [Python 2](https://docs.python.org/2/library/subprocess.html#subprocess.Popen.communicate) or [Python 3](https://docs.python.org/3/library/subprocess.html#subprocess.Popen.communicate). This causes a deadlock when calling ``bower freeze``.

The commit below fixes this issue.