### PR TITLE
Fix management command compatibility with Django 1.8

### DIFF
--- a/djangobower/management/commands/bower.py
+++ b/djangobower/management/commands/bower.py
@@ -3,6 +3,7 @@ from ..base import BaseBowerCommand
 
 
 class Command(BaseBowerCommand):
+    args = 'command'
     help = 'Call bower in components root ({0}).'.format(
         bower_adapter._components_root)
 


### PR DESCRIPTION
On Django 1.8 running `manage.py bower install` returns the following error:

```
manage.py bower: error: unrecognized arguments: install
```

This is because Django 1.8 switched to from optparse to argparse for parsing arguments.
The proposed fix is described here: https://docs.djangoproject.com/en/1.8/releases/1.8/#management-commands-that-only-accept-positional-arguments

I tested it locally on 1.8 and it fixes the error.