### PR TITLE
Add different Django versions to the Travis test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ env:
    - DJANGO_VERSION=1.4
    - DJANGO_VERSION=1.7
    - DJANGO_VERSION=1.8
+matrix:
+  exclude:
+    - python: "3.3"
+      env: DJANGO_VERSION=1.4
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq sloccount

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,17 @@ language: python
 python:
   - "2.7"
   - "3.3"
+env:
+  matrix:
+   - DJANGO_VERSION=1.4
+   - DJANGO_VERSION=1.7
+   - DJANGO_VERSION=1.8
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq sloccount
 install:
   - npm install -g bower
+  - pip install -q "Django>=${DJANGO_VERSION},<${DJANGO_VERSION}.99"
   - pip install -U .
   - pip install -U -r requirements_dev.txt
   - pip install pep8

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ before_install:
 install:
   - npm install -g bower
   - pip install -q "Django>=${DJANGO_VERSION},<${DJANGO_VERSION}.99"
-  - pip install -U .
-  - pip install -U -r requirements_dev.txt
+  - pip install .
+  - pip install -r requirements_dev.txt
   - pip install pep8
   - pip install coviolations_app
 script:


### PR DESCRIPTION
I added the versions that are still supported: 1.4, 1.7 and 1.8

Tests for 1.8 are currently failing because of #39