### PR TITLE
Avoid OSError crash when BOWER_COMPONENTS_ROOT's parent directory doesn't exist

### DIFF
--- a/djangobower/bower.py
+++ b/djangobower/bower.py
@@ -23,7 +23,7 @@ class BowerAdapter(object):
     def create_components_root(self):
         """Create components root if need"""
         if not os.path.exists(self._components_root):
-            os.mkdir(self._components_root)
+            os.makedirs(self._components_root)
 
     def call_bower(self, args):
         """Call bower with a list of args"""

--- a/djangobower/tests/test_bower.py
+++ b/djangobower/tests/test_bower.py
@@ -1,11 +1,33 @@
 from django.core.management import call_command
 from django.conf import settings
+from django.test import TestCase
 from six import StringIO
 from mock import MagicMock
 from ..bower import bower_adapter, BowerAdapter
 from .. import conf
 from .base import BaseBowerCase, TEST_COMPONENTS_ROOT
 import os
+import shutil
+
+
+class BowerAdapterCase(TestCase):
+    """
+    BowerAdapter regression tests.
+    """
+
+    def test_create_components_root_subdirs(self):
+        """
+        create_components_root() creates missing intermediate directories.
+        """
+        if os.path.exists(TEST_COMPONENTS_ROOT):
+            shutil.rmtree(TEST_COMPONENTS_ROOT)
+
+        subdir = os.path.join(TEST_COMPONENTS_ROOT, 'sub', 'dir')
+        adapter = BowerAdapter(conf.BOWER_PATH, subdir)
+        adapter.create_components_root()
+        self.assertTrue(os.path.exists(subdir))
+
+        shutil.rmtree(TEST_COMPONENTS_ROOT)
 
 
 class BowerInstallCase(BaseBowerCase):


### PR DESCRIPTION
If `BOWER_COMPONENTS_ROOT` points to a path consisting of more than one non-existent subdirectory, `BowerAdapter.create_components_root()` will crash with a message like:

```
OSError: [Errno 2] No such file or directory: '/path/to/directory'
```

This fix replaces the `os.mkdir()` call with `os.makedirs()`, which will create all the missing intermediate directories as needed.