### PR TITLE
Clean up BowerFinder, and don't crash when the Bower folder doesn't exist yet

### DIFF
--- a/djangobower/finders.py
+++ b/djangobower/finders.py
@@ -13,20 +13,25 @@ class BowerFinder(FileSystemFinder):
     """Find static files installed with bower"""
 
     def __init__(self, apps=None, *args, **kwargs):
-        self.locations = [
-            ('', self._get_bower_components_location()),
-        ]
+        self.locations = []
         self.storages = OrderedDict()
 
-        filesystem_storage = FileSystemStorage(location=self.locations[0][1])
-        filesystem_storage.prefix = self.locations[0][0]
-        self.storages[self.locations[0][1]] = filesystem_storage
+        root = self._get_bower_components_location()
+        if root is not None:
+            prefix = ''
+            self.locations.append((prefix, root))
+
+            filesystem_storage = FileSystemStorage(location=root)
+            filesystem_storage.prefix = prefix
+            self.storages[root] = filesystem_storage
 
     def _get_bower_components_location(self):
-        """Get bower components location"""
-        path = os.path.join(conf.COMPONENTS_ROOT, 'bower_components')
-
-        # for old bower versions:
-        if not os.path.exists(path):
-            path = os.path.join(conf.COMPONENTS_ROOT, 'components')
-        return path
+        """
+        Return the bower components location, or None if one does not exist.
+        """
+        # Bower 0.10 changed the default folder from 'components' to 'bower_components'.
+        # Try 'bower_components' first, then fall back to trying 'components'.
+        for name in ['bower_components', 'components']:
+            path = os.path.join(conf.COMPONENTS_ROOT, name)
+            if os.path.exists(path):
+                return path

--- a/djangobower/finders.py
+++ b/djangobower/finders.py
@@ -1,4 +1,8 @@
-import collections
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict
+
 from django.contrib.staticfiles.finders import FileSystemFinder
 from django.core.files.storage import FileSystemStorage
 from . import conf
@@ -12,11 +16,7 @@ class BowerFinder(FileSystemFinder):
         self.locations = [
             ('', self._get_bower_components_location()),
         ]
-        try:
-            self.storages = collections.OrderedDict()
-        except AttributeError:
-            from ordereddict import OrderedDict
-            self.storages = OrderedDict()
+        self.storages = OrderedDict()
 
         filesystem_storage = FileSystemStorage(location=self.locations[0][1])
         filesystem_storage.prefix = self.locations[0][0]

--- a/djangobower/tests/test_finders.py
+++ b/djangobower/tests/test_finders.py
@@ -1,8 +1,78 @@
+from django.core.files.storage import FileSystemStorage
+from django.test import TestCase
+
 from ..bower import bower_adapter
 from ..finders import BowerFinder
 from .. import conf
 from .base import BaseBowerCase
 import os
+import shutil
+
+
+class _MakeDirsTestCase(TestCase):
+    """
+    Helper to create and clean up test directories.
+    """
+
+    def setUp(self):
+        super(_MakeDirsTestCase, self).setUp()
+        self.created = []
+
+    def tearDown(self):
+        super(_MakeDirsTestCase, self).tearDown()
+        for name in self.created:
+            if os.path.exists(name):
+                shutil.rmtree(name)
+
+    def makedirs(self, name):
+        """
+        Wrap os.makedirs() to delete the created directory on teardown.
+        """
+        os.makedirs(name)
+        self.created.append(name)
+
+
+class SimpleBowerFinderCase(_MakeDirsTestCase):
+    """
+    Simple BowerFinder tests, without any packages installed.
+    """
+
+    def test_list_nonexistent(self):
+        """
+        When no Bower folder exists, just gracefully find nothing.
+        """
+        finder = BowerFinder()
+        self.assertEqual(finder.locations, [])
+        self.assertEqual(finder.storages, {})
+
+    def test_list_existent(self, leaf_name='bower_components'):
+        """
+        If 'bower_components' exists, use it to to find files.
+        """
+        root = os.path.join(conf.COMPONENTS_ROOT, leaf_name)
+        self.makedirs(root)
+        finder = BowerFinder()
+
+        self.assertEqual(finder.locations, [('', root)])
+
+        self.assertEqual(set(finder.storages.keys()), set([root]))
+        storage = finder.storages[root]
+        self.assertIsInstance(storage, FileSystemStorage)
+        self.assertEqual(storage.prefix, '')
+        self.assertEqual(storage.location, root)
+
+    def test_list_old_path(self):
+        """
+        If only the old 'components' folder exists, use it instead.
+        """
+        self.test_list_existent(leaf_name='components')
+
+    def test_list_both(self):
+        """
+        If both folders exist, only 'bower_components' should be used.
+        """
+        self.makedirs(os.path.join(conf.COMPONENTS_ROOT, 'components'))
+        self.test_list_existent(leaf_name='bower_components')
 
 
 class BowerFinderCase(BaseBowerCase):


### PR DESCRIPTION
This should prevent the obscure failure and error message of #48.