### PR TITLE
Skip Django checks for the commands

### DIFF
--- a/djangobower/management/base.py
+++ b/djangobower/management/base.py
@@ -8,6 +8,8 @@ from ..exceptions import BowerNotInstalled
 class BaseBowerCommand(BaseCommand):
     """Base management command with bower support"""
 
+    requires_system_checks = False
+
     def handle(self, *args, **options):
         self._check_bower_exists()
         bower_adapter.create_components_root()


### PR DESCRIPTION
For example, there is no needs of a working database to run this module commands.