### PR TITLE
don't choke on version in package#version

### DIFF
--- a/djangobower/context_processors.py
+++ b/djangobower/context_processors.py
@@ -8,6 +8,7 @@ from django.utils.datastructures import OrderedSet
 
 def read_mains():
     for component in settings.BOWER_INSTALLED_APPS:
+        component = component.split('#')[0]
         try:
             with open(os.path.join(
                     settings.BOWER_COMPONENTS_ROOT,


### PR DESCRIPTION
A little fix for [PR#57](https://github.com/nvbn/django-bower/pull/57), so that it supports version specification from `BOWER_INSTALLED_APPS`, e.g:


    BOWER_INSTALLED_APPS = ['jquery#2.2.3', ...]

Of course, it still works without the `#version` part, too.