### PR TITLE
Add option to bower_install to be able to install packages as root

### DIFF
--- a/djangobower/management/commands/bower_install.py
+++ b/djangobower/management/commands/bower_install.py
@@ -11,11 +11,20 @@ class Command(BaseBowerCommand):
                     dest='force',
                     default=False,
                     help='Force installation of latest package version on conflict'),
+        make_option('-R', '--allow-root',
+                    action='store_true',
+                    dest='allow-root',
+                    default=False,
+                    help='Allow installing bower packages even when user executing this script is root'),
     )
 
     def handle(self, *args, **options):
         super(Command, self).handle(*args, **options)
 
-        if options.get('force') == True:
+        if options.get('force'):
             args = args + ("-F", )
+
+        if options.get('allow-root'):
+            args = args + ("--allow-root", )
+        
         self._install(args)


### PR DESCRIPTION
In some deployment scenarios one needs to run bower as root even though it is discouraged. This pull request adds an option to django-bower's bower_install command to do just that. 