### PR TITLE
Changes needed to support Django 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
    - DJANGO_VERSION=1.7
    - DJANGO_VERSION=1.8
    - DJANGO_VERSION=1.9
+   - DJANGO_VERSION=1.10
 matrix:
   exclude:
     - python: "3.3"
@@ -22,6 +23,8 @@ matrix:
       env: DJANGO_VERSION=1.7
     - python: "3.3"
       env: DJANGO_VERSION=1.9
+    - python: "3.3"
+      env: DJANGO_VERSION=1.10
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq sloccount

--- a/djangobower/management/base.py
+++ b/djangobower/management/base.py
@@ -10,6 +10,10 @@ class BaseBowerCommand(BaseCommand):
 
     requires_system_checks = False
 
+    # add fake .options_list for Django>=1.10
+    if not hasattr(BaseCommand, 'option_list'):
+        option_list = ()
+
     def handle(self, *args, **options):
         self._check_bower_exists()
         bower_adapter.create_components_root()

--- a/djangobower/management/commands/bower.py
+++ b/djangobower/management/commands/bower.py
@@ -7,8 +7,13 @@ class Command(BaseBowerCommand):
     help = 'Call bower in components root ({0}).'.format(
         bower_adapter._components_root)
 
+    # for Django>=1.10
+    def add_arguments(self, parser):
+        parser.add_argument('command', nargs='+')
+
     def handle(self, *args, **options):
         super(Command, self).handle(*args, **options)
+        args = args or tuple(options.pop('command'))
         if self._is_single_command('install', args):
             self._install([])
         elif self._is_single_command('freeze', args):

--- a/djangobower/management/commands/bower_install.py
+++ b/djangobower/management/commands/bower_install.py
@@ -5,6 +5,7 @@ from ..base import BaseBowerCommand
 class Command(BaseBowerCommand):
     help = 'Install bower apps'
 
+    # for Django<1.10
     option_list = BaseBowerCommand.option_list + (
         make_option('-F',
                     action='store_true',
@@ -17,6 +18,20 @@ class Command(BaseBowerCommand):
                     default=False,
                     help='Allow installing bower packages even when user executing this script is root'),
     )
+    # for Django>=1.10
+    def add_arguments(self, parser):
+        parser.add_argument('--force',
+                            '-F',
+                            action='store_true',
+                            dest='force',
+                            default=False,
+                            help='Force installation of latest package version on conflict')
+        parser.add_argument('--allow-root',
+                            '-R',
+                            action='store_true',
+                            dest='allow-root',
+                            default=False,
+                            help='Allow installing bower packages even when user executing this script is root')
 
     def handle(self, *args, **options):
         super(Command, self).handle(*args, **options)


### PR DESCRIPTION
  - Added Django 1.10 to travis CI
  - added a "fake" option_list attribute to BaseBowerCommand
    so accesing this code elewhere won't break (doesn't exist in Dj 1.10)
  - Added support for the new add_arguemnts api for management commands,
    it seems the two APIs can coexist fine.
  - one test fails on Dj 1.9.9 (someone who knows mock better than me should look into this)


Inspired by https://github.com/rfk/django-supervisor/pull/51/files?diff=split

Needs some review + more tests, but otherwise seems to work...


