### PR TITLE
Work with requires_system_checks=()

### DIFF
--- a/djangobower/management/base.py
+++ b/djangobower/management/base.py
@@ -8,7 +8,7 @@ from ..exceptions import BowerNotInstalled
 class BaseBowerCommand(BaseCommand):
     """Base management command with bower support"""
 
-    requires_system_checks = False
+    requires_system_checks = ()
 
     # add fake .options_list for Django>=1.10
     if not hasattr(BaseCommand, 'option_list'):


### PR DESCRIPTION
Since Django-4.1, `requires_system_checks` should be a list or tuple listing the checks to perform. By setting it to an empty tuple, it will work on Django versions before and after 4.1, since the truthiness of an empty tuple is `False`.

See https://code.djangoproject.com/ticket/33896